### PR TITLE
Grammar issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Oven
-An util package that includes algorithms, functions and IO similar to those of other languages' standard libraries.
+A util package that includes algorithms, functions and IO similar to those of other languages' standard libraries.
 
 ## Installation
 Installation with pip is recommended.


### PR DESCRIPTION
_util_, as the shortened version of _utility_, still inherits the pronunciation of the latter. Therefore the _u_ is to be pronounced as is to be done in _p**u**ke_, rather than ~_f**u**ck_~ _l**u**ck_. As such, the article before it shall be _an_ in the stead of _a_, since there is a pronunciation of _y_ as in _**y**ikes_ before _u_.